### PR TITLE
OTA: Add Moto G82 5G (rhodep) to official devices

### DIFF
--- a/builds/rhodep.json
+++ b/builds/rhodep.json
@@ -1,0 +1,24 @@
+{
+  "response": [
+    {
+      "maintainer": "Akky",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "rhodep",
+      "filename": "Lunaris-AOSP-rhodep-Community-3.2-Gapps-2025090417.zip",
+      "download": "https://sourceforge.net/projects/ghosuto/files/rhodep/Lunaris-AOSP-rhodep-Community-3.2-Gapps-2025090417.zip/download",
+      "timestamp": 1757007562,
+      "md5": "63e373c9a41dc8c4898e8dd09e84a4b5",
+      "sha256": "da5c2e83d0f33eb2da7060519f308b291fa1683212cf100d890a794bf1be87a1",
+      "size": 2121265915,
+      "version": "3.2",
+      "buildtype": "user",
+      "forum": "https://t.me/akkybuilds",
+      "firmware": "",
+      "paypal": "",
+      "github": "https://github.com/Akkyhere",
+      "sourceforge": "https://sourceforge.net/projects/akky-builds/files/lunarisv3.2/Lunaris-AOSP-rhodep-Community-3.2-Gapps-2025090417.zip/download",
+      "initial_installation_images": []
+    }
+  ]
+}

--- a/changelogs/rhodep.txt
+++ b/changelogs/rhodep.txt
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+Initial Build
+- Android 16
+- All functions working without bug
+- Dolby added
+- ViperFX added


### PR DESCRIPTION
I, Akky, am applying as the official maintainer for Lunaris-AOSP on Rhodep. All current builds (3.2) are functional and tested. No changes to the official download URLs; my personal upload is only for backup purposes.

Maintainer: Akkyhere
Build: Lunaris-AOSP v3.2 (Community, Gapps)